### PR TITLE
Adding service version logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,9 @@ use fastly::experimental::RequestUpgradeWebsocket;
 use fastly::{Error, Request};
 
 fn main() -> Result<(), Error> {
+    // Log service version
+    println!("FASTLY_SERVICE_VERSION: {}", std::env::var("FASTLY_SERVICE_VERSION").unwrap_or_else(|_| String::new()));
+    
     let mut req = Request::from_client();
 
     if let Some("websocket") = req.get_header_str("Upgrade") {


### PR DESCRIPTION
Prints service version to console after running `fastly log-tail`. ([JIRA ticket](https://fastly.atlassian.net/browse/DEVLIB-856?atlOrigin=eyJpIjoiMDY0MmI0YThjZDVhNGE5NjljZjBiZGNjNTkzOWY2NDMiLCJwIjoiaiJ9))