### PR TITLE
Update to v2 of shared workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,6 @@ on:
 
 jobs:
   test:
-    uses: fastly/devex-reusable-workflows/.github/workflows/compute-starter-kit-rust-v1.yml@main
+    uses: fastly/devex-reusable-workflows/.github/workflows/compute-starter-kit-rust-v2.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This version of the workflow requires the GITHUB_TOKEN value so that one of its actions can use the GitHub API.