### PR TITLE
Update starter kit for CLI 15.2 and local testing of WebSocket passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,35 @@ The app expects a configured backend named `backend` that points to a WebSocket 
 
 After deploying the app and setting up the backend configuration, all connections received by the service will be passed to the backend.
 
-## Note
+### Enabling WebSockets passthrough
 
-This app is not currently supported in Fastly's [local development server](https://www.fastly.com/documentation/guides/compute/testing/#running-a-local-testing-server), as the development server does not support WebSockets features. To experiment with WebSockets, you will need to publish this project to your Fastly Compute service, using the `fastly compute publish` command.
+The first time this starter kit is deployed to your service, WebSockets passthrough is enabled automatically.
+
+To [enable WebSockets passthrough](https://www.fastly.com/documentation/guides/concepts/real-time-messaging/websockets-tunnel/#enabling-websockets-passthrough) support after the fact to an existing Fastly service, type:
+
+```shell
+fastly products --enable=websockets
+```
+
+## Testing locally
+
+If testing locally, make sure that you have a backend named `backend` defined in the `local_server` section of your `fastly.toml` file:
+
+```toml
+[local_server.backends]
+[local_server.backends.backend]
+url = "https://websockets.example.com/"
+override_host = "websockets.example.com"
+```
+
+## Notes
+
+The code in this starter kit cannot be used with the [`fastly::main` attribute](https://docs.rs/fastly/latest/fastly/attr.main.html) on the `main()` entry point. This is because a function decorated with `fastly::main` is expected to return a response, but handing off to Fanout is an action that does not create a response. Use an undecorated `main()` function instead, and use `Request::from_client()` and `Response::send_to_client()` as needed.
+
+## Compatibility
+
+- [Fastly CLI](https://www.fastly.com/documentation/reference/tools/cli/) 15.2.0 or newer
+- [Fastly Local Development Server (Viceroy)](https://www.fastly.com/documentation/guides/compute/developer-guides/testing/#running-a-local-testing-server) 0.18.0 or newer
 
 ## Security issues
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -6,3 +6,16 @@ manifest_version = 3
 
 [scripts]
   build = "cargo build --profile release"
+
+[local_server]
+[local_server.backends]
+[local_server.backends.backend]
+url = "https://echo.websocket.org/"
+override_host = "echo.websocket.org"
+
+[setup.backends]
+[setup.backends.backend]
+
+[setup.products]
+[setup.products.websockets]
+enable = true


### PR DESCRIPTION
This PR updates the starter kit to improve user experience:

- Adds example backend to WebSocket server echo.websocket.org (https://websocket.org/tools/websocket-echo-server)
- Adds setup for the WebSocket product as well as the backend with support since CLI 15.2
- Removes note in README saying this doesn't work in local testing, as it is now supported since Viceroy 0.18